### PR TITLE
Move temperature text above image in result section

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,8 +210,8 @@
 
     <div class="gallery">
         <div class="gallery-item">
-            <img src="ondo.jpg" alt="温度変化のグラフ">
             <p>この間の温度変化は、SwitchBot の温度計で測ってみたら以下のようでした。</p>
+            <img src="ondo.jpg" alt="温度変化のグラフ">
         </div>
     </div>
 


### PR DESCRIPTION

This PR moves the descriptive text about temperature measurement from below the "ondo.jpg" image to above it, as requested.

The change is minimal and only affects the HTML structure of the page. The content remains exactly the same, just reordered for better presentation.
